### PR TITLE
EBMEDS-1401: Publish docs on master push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,6 @@ workflows:
       - build-and-deploy:
           context: writable-github
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
-
-
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: escalate-git-priviledge
-          command: 'git remote rm origin && git remote add origin https://duodecimjenkins:$GITHUB_TOKEN@github.com/ebmeds/docs.git && git fetch origin && git pull origin master'
-      - run:
           name: update-pip
           command: 'pip install --upgrade pip'
       - run:


### PR DESCRIPTION
### [EBMEDS-1401](https://jira.duodecim.fi/browse/EBMEDS-1401)

This pull request switches the docs to publish on all master pushes rather than only on version tags. Also removes the seemingly extraneous git step from the job.