### PR TITLE
Add links from index to various documents

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ EBMEDS is developed by [Duodecim Medical Publications Ltd](http://www.ebmeds.org
 EBMEDS talks two different protocols, JSON-formatted FHIR STU3, and a native XML format:
 
 * [Get started with FHIR](api/fhir/getting-started.md)
+* [Installation](installation.md)
 
 # System requirements
 
@@ -24,4 +25,8 @@ See the [system requirements page](system-requirements.md) for a detailed overvi
 
 * [EBMEDS script descriptions](http://www.ebmeds.org/web/guest/scripts)
 * [Duodecim's FHIR resources](https://simplifier.net/DuodecimCDS)
+* [EBMEDS cloud](ebmeds-cloud.md)
 * [EBMEDS product lifecycle](api/lifecycle/index.md)
+* [EBMEDS supported browsers](supported-browsers.md)
+* [EBMEDS components](components.md)
+* [EBMEDS security](security.md)

--- a/docs/supported-browsers.md
+++ b/docs/supported-browsers.md
@@ -1,4 +1,4 @@
-Browser support
+# Browser support
 
 We officially support the last two versions of every major browser. Specifically, we test on the following browsers:
 


### PR DESCRIPTION
Added some links from index.md to documentation which is in the docs, but not accessible from the index.

So.. At least now we can access these resources from https://ebmeds.github.io/docs and mentioned in the text itself with a link.

There are still issues left in the github.io version of the docs. Those can be tackled with a separate ticket to jira and a separate PR. Now only addressing the fact that for example supported-browsers can be only accessed by knowing the direct link. With these links in the index, we move github.io version at least a notch forward in accessibility.